### PR TITLE
Don't use async methods except in one specific case

### DIFF
--- a/MechJamIV/CharacterBase.cs
+++ b/MechJamIV/CharacterBase.cs
@@ -7,9 +7,9 @@ namespace MechJamIV {
 	{
 
         [Signal]
-        public delegate void HealEventHandler(int hp);
+        public delegate void InjuredEventHandler(int damage);
         [Signal]
-        public delegate void HurtEventHandler(int damage);
+        public delegate void HealedEventHandler(int amount);
 
         [Export]
         public int Health { get; set; } = 100;
@@ -91,11 +91,11 @@ namespace MechJamIV {
 
         protected void AnimateMovement(Vector2 direction, double delta) => characterAnimator.AnimateMovement(direction, delta);
 
-        protected abstract System.Threading.Tasks.Task AnimateInjuryAsync(int damage, Vector2 normal);
+        protected abstract void AnimateInjury(int damage, Vector2 normal);
 
         protected void AnimateDeath() => characterAnimator.AnimateDeath();
 
-        public virtual async System.Threading.Tasks.Task HurtAsync(int damage, Vector2 normal)
+        public virtual void Hurt(int damage, Vector2 normal)
         {
             if (Health <= 0)
             {
@@ -104,22 +104,22 @@ namespace MechJamIV {
 
             Health = Math.Max(0, Health - damage);
 
-            EmitSignal(SignalName.Hurt, damage);
+            EmitSignal(SignalName.Injured, damage);
 
-            await AnimateInjuryAsync(damage, normal);
+            AnimateInjury(damage, normal);
 
             if (Health <= 0)
             {
                 AnimateDeath();
 
                 //TODO the game is reacting poorly when we free the player
-                //await ToSignal(GetTree().CreateTimer(5.0f), SceneTreeTimer.SignalName.Timeout);
+                //await ToSignal(GetTree().CreateTimer(5.0f, processInPhysics:true), SceneTreeTimer.SignalName.Timeout);
 
 			    //QueueFree();
             }
         }
 
-		public virtual async System.Threading.Tasks.Task HealAsync(int amount)
+		public virtual void Heal(int amount)
 		{
             if (Health <= 0)
             {
@@ -129,7 +129,7 @@ namespace MechJamIV {
             //TODO we need to know initial/max health
             Health = Math.Min(100, Health + amount);
 
-            EmitSignal(SignalName.Heal, amount);
+            EmitSignal(SignalName.Healed, amount);
 		}
 
 	}

--- a/MechJamIV/EnemyBase.cs
+++ b/MechJamIV/EnemyBase.cs
@@ -24,8 +24,8 @@ namespace MechJamIV {
             {
                 if (node is Hitbox hitbox)
                 {
-                    hitbox.Hit += async (damage, normal) => await HurtAsync(damage, normal);
-                    hitbox.Colliding += async (body) =>
+                    hitbox.Hit += (damage, normal) => Hurt(damage, normal);
+                    hitbox.Colliding += (body) =>
                     {
                         if (Health <= 0)
                         {
@@ -34,27 +34,25 @@ namespace MechJamIV {
 
                         if (body is Player player)
                         {
-                            await player.HurtAsync(hitbox.Damage, Vector2.Zero);
+                            player.Hurt(hitbox.Damage, Vector2.Zero);
                         }
                     };
                 }
             }
         }
 
-        public override async System.Threading.Tasks.Task HurtAsync(int damage, Vector2 normal)
+        public override void Hurt(int damage, Vector2 normal)
         {
             if (Health <= 0)
             {
                 return;
             }
 
-            await base.HurtAsync(damage, normal);
+            base.Hurt(damage, normal);
 
             if (Health <= 0)
             {
-                await ToSignal(GetTree().CreateTimer(5.0f), SceneTreeTimer.SignalName.Timeout);
-
-			    QueueFree();
+                this.TimedFree(5.0f, processInPhysics:true);
             }
         }
 

--- a/MechJamIV/NodeHelper.cs
+++ b/MechJamIV/NodeHelper.cs
@@ -1,0 +1,17 @@
+using Godot;
+using System;
+using System.Collections.Generic;
+
+namespace MechJamIV {
+    public static class NodeHelper
+    {
+
+        public static async void TimedFree(this Node node, double timeSec, bool processAlways = true, bool processInPhysics = false, bool ignoreTimeScale = false)
+        {
+			await node.ToSignal(node.GetTree().CreateTimer(timeSec, processAlways, processInPhysics, ignoreTimeScale), SceneTreeTimer.SignalName.Timeout);
+
+			node.QueueFree();
+        }
+
+    }
+}

--- a/scenes/grenade.tscn
+++ b/scenes/grenade.tscn
@@ -109,6 +109,12 @@ script = ExtResource("4_twoyx")
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 shape = SubResource("CircleShape2D_b3mic")
 
+[node name="ExplosionTimer" type="Timer" parent="."]
+process_callback = 0
+wait_time = 3.0
+one_shot = true
+autostart = true
+
 [node name="ExplosionAreaOfEffect" type="Area2D" parent="."]
 collision_layer = 8
 collision_mask = 110

--- a/scenes/player.tscn
+++ b/scenes/player.tscn
@@ -318,6 +318,11 @@ script = ExtResource("4_wlw4n")
 position = Vector2(0, 6.5)
 shape = SubResource("RectangleShape2D_euxq4")
 
+[node name="ImmunityTimer" type="Timer" parent="."]
+process_callback = 0
+wait_time = 2.0
+one_shot = true
+
 [node name="ImmunityShield" parent="." instance=ExtResource("4_y0w7f")]
 visible = false
 position = Vector2(0, 7)

--- a/scripts/Barrel.cs
+++ b/scripts/Barrel.cs
@@ -1,11 +1,12 @@
 using Godot;
 using System;
+using MechJamIV;
 
 public partial class Barrel : RigidBody2D
 {
 
 	[Signal]
-	public delegate void HurtEventHandler(int damage);
+	public delegate void InjuredEventHandler(int damage);
 
 	#region Resources
 
@@ -13,7 +14,7 @@ public partial class Barrel : RigidBody2D
 
 	#endregion
 
-	protected virtual async System.Threading.Tasks.Task AnimateInjuryAsync(int damage, Vector2 normal)
+	protected virtual void AnimateInjury(int damage, Vector2 normal)
     {
         GpuParticles2D splatter = shrapnelSplatter.Instantiate<GpuParticles2D>();
 
@@ -21,14 +22,12 @@ public partial class Barrel : RigidBody2D
 
 		splatter.Emitting = true;
 
-		await ToSignal(GetTree().CreateTimer(5.0f), SceneTreeTimer.SignalName.Timeout);
-
-		splatter.QueueFree();
+		this.TimedFree(splatter.Lifetime + splatter.Lifetime * splatter.Randomness, processInPhysics:true);
     }
 
-	public virtual async System.Threading.Tasks.Task HurtAsync(int damage, Vector2 normal)
+	public virtual void Hurt(int damage, Vector2 normal)
 	{
-		await AnimateInjuryAsync(damage, normal);
+		AnimateInjury(damage, normal);
 	}
 
 }

--- a/scripts/EnemyMech.cs
+++ b/scripts/EnemyMech.cs
@@ -27,7 +27,7 @@ public partial class EnemyMech : EnemyBase
         throw new NotImplementedException();
     }
 
-	protected async override System.Threading.Tasks.Task AnimateInjuryAsync(int damage, Vector2 normal)
+	protected override void AnimateInjury(int damage, Vector2 normal)
     {
         GpuParticles2D splatter = shrapnelSplatter.Instantiate<GpuParticles2D>();
 
@@ -35,9 +35,7 @@ public partial class EnemyMech : EnemyBase
 
 		splatter.Emitting = true;
 
-		await ToSignal(GetTree().CreateTimer(5.0f), SceneTreeTimer.SignalName.Timeout);
-
-		splatter.QueueFree();
+		this.TimedFree(splatter.Lifetime + splatter.Lifetime * splatter.Randomness, processInPhysics:true);
     }
 
 }

--- a/scripts/EnemyTroid.cs
+++ b/scripts/EnemyTroid.cs
@@ -24,7 +24,7 @@ public partial class EnemyTroid : EnemyBase
         throw new NotImplementedException();
     }
 
-	protected async override System.Threading.Tasks.Task AnimateInjuryAsync(int damage, Vector2 normal)
+	protected override void AnimateInjury(int damage, Vector2 normal)
     {
         GpuParticles2D splatter = acidSplatter.Instantiate<GpuParticles2D>();
 
@@ -32,9 +32,7 @@ public partial class EnemyTroid : EnemyBase
 
 		splatter.Emitting = true;
 
-		await ToSignal(GetTree().CreateTimer(5.0f), SceneTreeTimer.SignalName.Timeout);
-
-		splatter.QueueFree();
+		this.TimedFree(splatter.Lifetime + splatter.Lifetime * splatter.Randomness, processInPhysics:true);
     }
 
 }

--- a/scripts/ExplosiveBarrel.cs
+++ b/scripts/ExplosiveBarrel.cs
@@ -39,18 +39,18 @@ public partial class ExplosiveBarrel : Barrel
 
 	protected virtual void AnimateDeath() => characterAnimator.AnimateDeath();
 
-	public override async System.Threading.Tasks.Task HurtAsync(int damage, Vector2 normal)
+	public override void Hurt(int damage, Vector2 normal)
 	{
 		if (Health <= 0)
 		{
 			return;
 		}
 
-		await base.HurtAsync(damage, normal);
+		base.Hurt(damage, normal);
 
 		Health = Math.Max(0, Health - damage);
 
-		EmitSignal(SignalName.Hurt, damage);
+		EmitSignal(SignalName.Injured, damage);
 
 		if (Health <= 0)
 		{
@@ -58,13 +58,11 @@ public partial class ExplosiveBarrel : Barrel
 
 			Explode();
 
-			await ToSignal(GetTree().CreateTimer(5.0f), SceneTreeTimer.SignalName.Timeout);
-
-			QueueFree();
+			this.TimedFree(5.0f, processInPhysics:true);
 		}
 	}
 
-	private async void Explode()
+	private void Explode()
 	{
 		PhysicsShapeQueryParameters2D queryParams = new ();
 		queryParams.Transform = GlobalTransform;
@@ -78,14 +76,14 @@ public partial class ExplosiveBarrel : Barrel
 			{
 				Vector2 directionToCharacter = character.GlobalTransform.Origin - GlobalTransform.Origin;
 
-				await character.HurtAsync(Damage, directionToCharacter.Normalized());
+				character.Hurt(Damage, directionToCharacter.Normalized());
 				character.Velocity += ExplosionIntensity * directionToCharacter / directionToCharacter.LengthSquared();
 			}
 			else if (collision["collider"].Obj is Barrel barrel)
 			{
 				Vector2 directionToBarrel = barrel.GlobalTransform.Origin - GlobalTransform.Origin;
 
-				await barrel.HurtAsync(Damage, directionToBarrel.Normalized());
+				barrel.Hurt(Damage, directionToBarrel.Normalized());
 				barrel.ApplyImpulse(ExplosionIntensity * directionToBarrel / directionToBarrel.LengthSquared());
 			}
 		}

--- a/scripts/Grenade.cs
+++ b/scripts/Grenade.cs
@@ -9,11 +9,18 @@ public partial class Grenade : ExplosiveBarrel
 	[Export]
 	public override int Health { get; set; } = 1;
 
-	public async System.Threading.Tasks.Task PullPinAsync()
-	{
-		await ToSignal(GetTree().CreateTimer(3.0f), SceneTreeTimer.SignalName.Timeout);
+	#region Node references
 
-		await HurtAsync(Health, Vector2.Zero);
-	}
+	private Timer explosionTimer;
+
+	#endregion
+
+    public override void _Ready()
+    {
+        base._Ready();
+
+		explosionTimer = GetNode<Timer>("ExplosionTimer");
+		explosionTimer.Timeout += () => Hurt(Health, Vector2.Zero);
+    }
 
 }

--- a/scripts/HitScanBulletEmitter.cs
+++ b/scripts/HitScanBulletEmitter.cs
@@ -23,7 +23,7 @@ public partial class HitScanBulletEmitter : Node2D
 		_bodiesToExclude = new Godot.Collections.Array<Rid>(resourceIds);
 	}
 
-	public async void Fire(Vector2 mousePos)
+	public void Fire(Vector2 mousePos)
 	{
 		Godot.Collections.Dictionary collision = GetWorld2D().DirectSpaceState.IntersectRay(new PhysicsRayQueryParameters2D()
 		{
@@ -45,12 +45,12 @@ public partial class HitScanBulletEmitter : Node2D
 			}
 			else if (collision["collider"].Obj is Barrel barrel)
 			{
-				await barrel.HurtAsync(Damage, normal);
+				barrel.Hurt(Damage, normal);
 			}
 			//BUG: Grenades are not currently in the Environment layer. (See kanban task.)
 			else if (collision["collider"].Obj is Grenade grenade)
 			{
-				await grenade.HurtAsync(Damage, normal);
+				grenade.Hurt(Damage, normal);
 			}
 			else
 			{

--- a/scripts/Robot.cs
+++ b/scripts/Robot.cs
@@ -30,7 +30,7 @@ public partial class Robot : CharacterBase
 		//TODO
 	}
 
-	protected async override System.Threading.Tasks.Task AnimateInjuryAsync(int damage, Vector2 normal)
+	protected override void AnimateInjury(int damage, Vector2 normal)
 	{
 		//TODO
 	}

--- a/scripts/Spikes.cs
+++ b/scripts/Spikes.cs
@@ -13,13 +13,13 @@ public partial class Spikes : Area2D
 
 	public override void _Ready()
 	{
-		BodyEntered += (body) =>
+		BodyEntered += async (body) =>
 		{
 			if (body is Player player)
 			{
 				collidingBodies.Add(player.GetRid(), player);
 
-				player.HurtAsync(Damage, Vector2.Zero);
+				await player.HurtAsync(Damage, Vector2.Zero);
 			}
 		};
 		BodyExited += (body) =>

--- a/scripts/Spikes.cs
+++ b/scripts/Spikes.cs
@@ -13,13 +13,13 @@ public partial class Spikes : Area2D
 
 	public override void _Ready()
 	{
-		BodyEntered += async (body) =>
+		BodyEntered += (body) =>
 		{
 			if (body is Player player)
 			{
 				collidingBodies.Add(player.GetRid(), player);
 
-				await player.HurtAsync(Damage, Vector2.Zero);
+				player.Hurt(Damage, Vector2.Zero);
 			}
 		};
 		BodyExited += (body) =>
@@ -37,7 +37,7 @@ public partial class Spikes : Area2D
 		{
 			foreach (KeyValuePair<Rid, Player> kvp in collidingBodies)
 			{
-				kvp.Value.HurtAsync(Damage, Vector2.Zero);
+				kvp.Value.Hurt(Damage, Vector2.Zero);
 			}
 		}
 	}

--- a/scripts/World.cs
+++ b/scripts/World.cs
@@ -21,8 +21,8 @@ public partial class World : Node2D
 	public override void _Ready()
 	{
 		player = GetNode<Player>("Player");
-		player.Heal += (hp) => healthBar.Value = player.Health;
-		player.Hurt += (hp) => healthBar.Value = player.Health;
+		player.Injured += (damage) => healthBar.Value = player.Health;
+		player.Healed += (amount) => healthBar.Value = player.Health;
 		player.ImmunityShieldActivated += () => immunityShield.Visible = true;
 		player.ImmunityShieldDeactivated += () => immunityShield.Visible = false;
 


### PR DESCRIPTION
Godot's API is not asynchronous so adding async methods only caused race conditions. There is, however, one use case that has been popularized and that is to await SceneTreeTimer.Timeout immediately before calling Node.QueueFree().

This PR adds a helper for this use case and a refactor.