### PR TITLE
#57: Revert game state when restarting level/game

### DIFF
--- a/MechJamIV/IUpdateable.cs
+++ b/MechJamIV/IUpdateable.cs
@@ -3,13 +3,15 @@ using System;
 
 namespace MechJamIV
 {
-    public interface IUpdateable<T>
+    public interface IUpdateable
     {
 
         //[Signal]
-        delegate void UpdatedEventHandler();
+        delegate void LoadedEventHandler();
 
-        void DeferredUpdateFrom(T source);
+        void Save(ConfigFile config);
+
+        void DeferredLoad(ConfigFile config);
 
     }
 }

--- a/scripts/global/ConfigManager.cs
+++ b/scripts/global/ConfigManager.cs
@@ -49,16 +49,16 @@ public partial class ConfigManager : Node
         }
 
         string section = "Pickup";
-        MedkitHealth = (int)config.GetValue(section, nameof(MedkitHealth), 50);
-        MissileAmmo = (int)config.GetValue(section, nameof(MissileAmmo), 1);
-        RifleAmmo = (int)config.GetValue(section, nameof(RifleAmmo), 30);
+        MedkitHealth = config.GetValue(section, nameof(MedkitHealth), 50).AsInt32();
+        MissileAmmo = config.GetValue(section, nameof(MissileAmmo), 1).AsInt32();
+        RifleAmmo = config.GetValue(section, nameof(RifleAmmo), 30).AsInt32();
 
         section = "World";
-        SpikeDamage = (int)config.GetValue(section, nameof(SpikeDamage), 10);
-        SpawnHealth = (int)config.GetValue(section, nameof(SpawnHealth), 10);
+        SpikeDamage = config.GetValue(section, nameof(SpikeDamage), 10).AsInt32();
+        SpawnHealth = config.GetValue(section, nameof(SpawnHealth), 10).AsInt32();
 
         section = "UI";
-        MouseSensitivity = (float)config.GetValue(section, nameof(MouseSensitivity), 300.0f);
+        MouseSensitivity = config.GetValue(section, nameof(MouseSensitivity), 300.0f).AsSingle();
     }
 
 }

--- a/scripts/global/SceneManager.cs
+++ b/scripts/global/SceneManager.cs
@@ -21,10 +21,10 @@ public partial class SceneManager : Node
 
     public static void GoToScene(string path)
     {
+        reloadConfig.Clear();
+
         if (currentScene is World source)
         {
-            reloadConfig.Clear();
-
             source.Save(reloadConfig);
         }
 
@@ -64,8 +64,6 @@ public partial class SceneManager : Node
         if (currentScene is World target)
         {
             // BUG #56: Set minimum player health/ammo
-            // BUG #57: Restart level works but restart game still persists game state!
-
 
             target.Loaded += previousScene.Free;
 

--- a/scripts/global/SceneManager.cs
+++ b/scripts/global/SceneManager.cs
@@ -8,6 +8,8 @@ public partial class SceneManager : Node
 
     private static Node currentScene = null!;
 
+    private static readonly ConfigFile reloadConfig = new();
+
     public override void _Ready()
     {
         Instance ??= this;
@@ -19,15 +21,22 @@ public partial class SceneManager : Node
 
     public static void GoToScene(string path)
     {
-        Instance.CallDeferred(MethodName.DeferredGoToScene, path);
+        if (currentScene is World source)
+        {
+            reloadConfig.Clear();
+
+            source.Save(reloadConfig);
+        }
+
+        Instance.CallDeferred(MethodName.DeferredGoToScene, path, reloadConfig);
     }
 
     public static void ReloadScene()
     {
-        Instance.CallDeferred(MethodName.DeferredGoToScene, currentScene.SceneFilePath);
+        Instance.CallDeferred(MethodName.DeferredGoToScene, currentScene.SceneFilePath, reloadConfig);
     }
 
-    private static void DeferredGoToScene(string path)
+    private static void DeferredGoToScene(string path, ConfigFile config)
     {
         // NOTE: There is more than one way to load a scene into the
         //       scene tree. For a simpler game with simple levels,
@@ -52,14 +61,15 @@ public partial class SceneManager : Node
         // this is really important and is what SceneTree.change_scene_to_file() would do
         Instance.GetTree().CurrentScene = currentScene;
 
-        if (previousScene is World source && currentScene is World target)
+        if (currentScene is World target)
         {
             // BUG #56: Set minimum player health/ammo
-            // BUG #57: Restart level isn't getting the original values
+            // BUG #57: Restart level works but restart game still persists game state!
 
-            target.Updated += previousScene.Free;
 
-            target.DeferredUpdateFrom(source);
+            target.Loaded += previousScene.Free;
+
+            target.DeferredLoad(config);
         }
         else
         {

--- a/scripts/levels/World.cs
+++ b/scripts/levels/World.cs
@@ -6,7 +6,7 @@ using MechJamIV;
 using System.Diagnostics;
 
 public partial class World : Node2D,
-    IUpdateable<World>
+    IUpdateable
 {
 
     [Export(PropertyHint.File, "*.tscn,")]
@@ -269,13 +269,18 @@ public partial class World : Node2D,
     #region IUpdateable
 
     [Signal]
-    public delegate void UpdatedEventHandler();
+    public delegate void LoadedEventHandler();
 
-    public void DeferredUpdateFrom(World source)
+    public void Save(ConfigFile config)
     {
-        player.Updated += () => EmitSignal(SignalName.Updated);
+        player.Save(config);
+    }
 
-        player.DeferredUpdateFrom(source.player);
+    public void DeferredLoad(ConfigFile config)
+    {
+        player.Loaded += () => EmitSignal(SignalName.Loaded);
+
+        player.DeferredLoad(config);
     }
 
     #endregion

--- a/scripts/players/Player.cs
+++ b/scripts/players/Player.cs
@@ -5,7 +5,7 @@ using System.Diagnostics;
 
 public partial class Player : CharacterBase,
     IPlayable,
-    IUpdateable<Player>
+    IUpdateable
 {
 
     private bool isImmune = false;
@@ -123,15 +123,27 @@ public partial class Player : CharacterBase,
     #region IUpdateable
 
     [Signal]
-    public delegate void UpdatedEventHandler();
+    public delegate void LoadedEventHandler();
 
-    public void DeferredUpdateFrom(Player source)
+    public void Save(ConfigFile config)
     {
-        Heal(source.Health - Health, true);
+        config.SetValue(nameof(Player), nameof(Health), Health);
 
-        WeaponManager.Updated += () => EmitSignal(SignalName.Updated);
+        WeaponManager.Save(config);
+    }
 
-        WeaponManager.DeferredUpdateFrom(source.WeaponManager);
+    public void DeferredLoad(ConfigFile config)
+    {
+        if (config.HasSectionKey(nameof(Player), nameof(Health)))
+        {
+            int health = config.GetValue(nameof(Player), nameof(Health)).AsInt32();
+
+            Heal(health - Health, true);
+        }
+
+        WeaponManager.Loaded += () => EmitSignal(SignalName.Loaded);
+
+        WeaponManager.DeferredLoad(config);
     }
 
     #endregion

--- a/scripts/weapons/WeaponManager.cs
+++ b/scripts/weapons/WeaponManager.cs
@@ -6,7 +6,7 @@ using MechJamIV;
 using System.Diagnostics;
 
 public partial class WeaponManager : Node2D,
-    IUpdateable<WeaponManager>
+    IUpdateable
 {
 
     [Signal]
@@ -208,28 +208,52 @@ public partial class WeaponManager : Node2D,
     #region IUpdateable
 
     [Signal]
-    public delegate void UpdatedEventHandler();
+    public delegate void LoadedEventHandler();
 
-    public void DeferredUpdateFrom(WeaponManager source)
+    public void Save(ConfigFile config)
     {
         //TODO what if we want to start without weapons?
 
-        foreach (WeaponBase sourceWeapon in source.weapons.Values)
+        foreach (KeyValuePair<PickupType, WeaponBase> kvp in weapons)
         {
-            if (!weapons.ContainsKey(sourceWeapon.WeaponType))
-            {
-                DeferredPickup(sourceWeapon.WeaponType);
-            }
+            config.SetValue($"{nameof(WeaponManager)}:{kvp.Key}", nameof(WeaponBase.Ammo), kvp.Value.Ammo);
+        }
 
-            if (weapons.TryGetValue(sourceWeapon.WeaponType, out WeaponBase? weapon))
+        //TODO don't save if not selected?
+        // config.SetValue(nameof(WeaponManager), "PrimaryWeaponType", (int)(PrimaryWeapon?.WeaponType ?? (PickupType)(-1)));
+        // config.SetValue(nameof(WeaponManager), "SecondaryWeaponType", (int)(SecondaryWeapon?.WeaponType ?? (PickupType)(-1)));
+    }
+
+    public void DeferredLoad(ConfigFile config)
+    {
+        foreach (PickupType pickupType in Enum.GetValues<PickupType>())
+        {
+            if (config.HasSectionKey($"{nameof(WeaponManager)}:{pickupType}", nameof(WeaponBase.Ammo)))
             {
-                weapon.SetAmmo(sourceWeapon.Ammo);
+                if (!weapons.ContainsKey(pickupType))
+                {
+                    DeferredPickup(pickupType);
+                }
+
+                if (weapons.TryGetValue(pickupType, out WeaponBase? weapon))
+                {
+                    weapon.SetAmmo(config.GetValue($"{nameof(WeaponManager)}:{pickupType}", nameof(WeaponBase.Ammo)).AsInt32());
+                }
             }
         }
 
         //TODO need to copy the selected weapon types (can cycle primary/secondary until they match the source)
+        // if (config.HasSectionKey(nameof(WeaponManager), "PrimaryWeaponType"))
+        // {
+        //     _ = config.GetValue(nameof(WeaponManager), "PrimaryWeaponType");
+        // }
 
-        EmitSignal(SignalName.Updated);
+        // if (config.HasSectionKey(nameof(WeaponManager), "SecondaryWeaponType"))
+        // {
+        //     _ = config.GetValue(nameof(WeaponManager), "SecondaryWeaponType");
+        // }
+
+        EmitSignal(SignalName.Loaded);
     }
 
     #endregion


### PR DESCRIPTION
This implements more comprehensive save/load config using `ConfigFile` to persist game state between levels. This allows for storing game state at the beginning of each level which can be reloaded.